### PR TITLE
Updated health check fields

### DIFF
--- a/break-monolith-apart1.md
+++ b/break-monolith-apart1.md
@@ -582,7 +582,7 @@ When you import the _smallrye-health extension_, the `/health` endpoint is autom
 
 ~~~json
 {
-      "outcome": "UP",
+      "status": "UP",
      "checks": [
      ]
 }
@@ -590,10 +590,10 @@ When you import the _smallrye-health extension_, the `/health` endpoint is autom
 
 The health REST enpoint returns a simple JSON object with two fields:
 
- * **outcome** - the overall result of all the health check procedures
+ * **status** - the overall result of all the health check procedures
  * **checks** - an array of individual checks
 
-The general _outcome_ of the health check is computed as a logical AND of all the declared health check procedures.
+The general _status_ of the health check is computed as a logical AND of all the declared health check procedures.
 The _checks_ array is empty as we have not specified any health check procedure yet so let’s define some.
 
 ####15. Create your first health check


### PR DESCRIPTION
The guide suggested that the health check has an 'outcome' field; the actual field in the output is "status"

![image](https://user-images.githubusercontent.com/720824/69282483-6b482680-0bb8-11ea-992f-f9e12139b353.png)
